### PR TITLE
Fixed invalid board ID logic

### DIFF
--- a/otsdaq-mu2e-calorimeter/FEInterfaces/ROCCalorimeterInterface.h
+++ b/otsdaq-mu2e-calorimeter/FEInterfaces/ROCCalorimeterInterface.h
@@ -161,11 +161,12 @@ class ROCCalorimeterInterface : public ROCPolarFireCoreInterface {
 
     bool     haveBoardIdFromSerial_ = false;
     uint16_t cachedSerialReg147_    = 0;
-    uint16_t cachedBoardIdFromDB_   = 0;
+    uint16_t cachedBoardIdFromDB_   = 9999;
     void updateBoardIdFromSerial_();
 
     static constexpr int MAX_BOARD_ID = 160;  // Maximum valid board ID for calorimeter DIRACs, see also CaloConst::_nDIRAC from Offline/DataProducts/inc/CaloConst.hh
     static const std::set<DTCLib::roc_address_t>		SPECIAL_BLOCK_READ_ADDRS_;
+    static constexpr int INVALID_BOARDID = 9999;
 
     std::set<int> _pin_diode_list;
 

--- a/otsdaq-mu2e-calorimeter/FEInterfaces/ROCCalorimeterInterface_interface.cc
+++ b/otsdaq-mu2e-calorimeter/FEInterfaces/ROCCalorimeterInterface_interface.cc
@@ -291,7 +291,7 @@ void ROCCalorimeterInterface::ROCSlowControl(__ARGS__) {
 	const int boardID = static_cast<int>(cachedBoardIdFromDB_);
 	__COUT_INFO__ << "Target BoardID = " << boardID << __E__;
 
-	if(!cachedBoardIdFromDB_) {
+	if(cachedBoardIdFromDB_ == INVALID_BOARDID) {
 		__FE_SS__ << "Skipping tag slow control for board " << boardID << ", boardID not initialized correctly!" << __E__;
 		__FE_SS_THROW__;
 		return;
@@ -782,7 +782,7 @@ void ots::ROCCalorimeterInterface::FindBoardIDFromSerial(__ARGS__) {
 void ROCCalorimeterInterface::updateBoardIdFromSerial_() {
 	haveBoardIdFromSerial_ = false;
 	cachedSerialReg147_    = 0;
-	cachedBoardIdFromDB_   = 0;
+	cachedBoardIdFromDB_   = INVALID_BOARDID;
 
 	cachedSerialReg147_ = readRegister(147);
 
@@ -1145,9 +1145,9 @@ void ROCCalorimeterInterface::ConfigureLink(std::string conf, std::string confFi
 	const int boardID = static_cast<int>(cachedBoardIdFromDB_);
 	__COUT_INFO__ << "Target BoardID = " << boardID << __E__;
 
-	if(!cachedBoardIdFromDB_) {
+	if(cachedBoardIdFromDB_ == INVALID_BOARDID) {
 		updateBoardIdFromSerial_();
-		if(!cachedBoardIdFromDB_) {
+		if(cachedBoardIdFromDB_ == INVALID_BOARDID) {
 			__FE_SS__ << "Skipping configuring board " << boardID << ", boardID not initialized correctly!" << __E__;
 			__FE_SS_THROW__;
 			return;
@@ -1184,7 +1184,7 @@ void ROCCalorimeterInterface::CalibrateMZB() {
 	const int boardID = static_cast<int>(cachedBoardIdFromDB_);
 	__COUT_INFO__ << "Target BoardID = " << boardID << __E__;
 
-	if(!cachedBoardIdFromDB_) {
+	if(cachedBoardIdFromDB_ == INVALID_BOARDID) {
 		__FE_SS__ << "Skipping upload MZB parameters to board " << boardID << ", boardID not initialized correctly!" << __E__;
 		__FE_SS_THROW__;
 		return;
@@ -1257,7 +1257,7 @@ void ROCCalorimeterInterface::SetADCsThresholds(int offset) {
 		return;
 	}
 
-	if(!cachedBoardIdFromDB_) {
+	if(cachedBoardIdFromDB_ == INVALID_BOARDID) {
 		__COUT_ERR__ << "Skipping setting thresholds to board " << boardID << ", boardID not initialized correctly!" << __E__;
 		return;
 	}


### PR DESCRIPTION
Bugfix: previous logic implied that boardID == 0 was invalid.